### PR TITLE
fixed custom config using for bull

### DIFF
--- a/src/Queue.js
+++ b/src/Queue.js
@@ -21,7 +21,7 @@ class Queue {
     const redis = Config.get('redis')
     const { connection } = Config.get('bull')
 
-    this.config = redis[connection]
+    this.config =  { redis: redis[connection] }
   }
 
   _getJobListeners (Job) {


### PR DESCRIPTION
compared to Bull's Quick Guide:

`var audioQueue = new Queue('audio transcoding', {redis: {port: 6379, host: '127.0.0.1', password: 'foobared'}}); // Specify Redis connection using object
`