### PR TITLE
chore: Improve config to connection with redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,20 +37,31 @@ const Env = use("Env");
 
 module.exports = {
   // redis connection
-  connection: Env.get("BULL_CONNECTION", "BULL")
+  connection: Env.get("BULL_CONNECTION", "bull"),
+  bull: {
+    redis: {
+      host: "127.0.0.1",
+      port: 6379,
+      password: null,
+      db: 0,
+      keyPrefix: ""
+    }
+  },
+  other: "redis://redis.example.com?password=correcthorsebatterystaple"
 };
 ```
+
+In the above file you can define redis connections, there you can pass all `Bull` queue configurations described [here](https://github.com/OptimalBits/bull/blob/develop/REFERENCE.md#queue).
 
 Create a file to initiate `Bull` at `preloads/bull.js`:
 
 ```js
 const Bull = use("Rocketseat/Bull");
 
-Bull.process();
-
-// Optionally you can start BullBoard:
-Bull.ui();
-// http://localhost:9999
+Bull.process()
+  // Optionally you can start BullBoard:
+  .ui(9999); // http://localhost:9999
+// You don't need to specify the port, the default number is 9999
 ```
 
 Add .preLoad in server.js to initialize the bull preload
@@ -95,6 +106,17 @@ class UserRegisterEmail {
 }
 
 module.exports = UserRegisterEmail;
+```
+
+You can use the `connection` static get method to specify which connection your `job` will work.
+
+```js
+class UserRegisterEmail {
+  // ...
+  static get connection() {
+    return "other";
+  }
+}
 ```
 
 ### Events

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ module.exports = {
       keyPrefix: ""
     }
   },
-  other: "redis://redis.example.com?password=correcthorsebatterystaple"
+  remote: "redis://redis.example.com?password=correcthorsebatterystaple"
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ You can use the `connection` static get method to specify which connection your 
 class UserRegisterEmail {
   // ...
   static get connection() {
-    return "other";
+    return "remote";
   }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketseat/adonis-bull",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "main": "src/Queue.js",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "bull": "^3.12.0",
-    "bull-board": "^0.5.0",
+    "bull-board": "0.6.0",
     "date-fns": "^2.7.0",
     "human-interval": "^0.1.6"
   }

--- a/src/Queue.js
+++ b/src/Queue.js
@@ -18,10 +18,10 @@ class Queue {
 
     this._queues = null
 
-    const redis = Config.get('redis')
-    const { connection } = Config.get('bull')
+    const { connection, ...connections } = Config.get('bull')
 
-    this.config =  { redis: redis[connection] }
+    this.config = connections[connection]
+    this.connections = connections
   }
 
   _getJobListeners (Job) {
@@ -42,8 +42,13 @@ class Queue {
       this._queues = this.jobs.reduce((queues, path) => {
         const Job = this.app.use(path)
 
+        const config = this.config
+        if (Job.connection) {
+          config.redis = this.connections[Job.connection]
+        }
+
         queues[Job.key] = {
-          bull: new Bull(Job.key, this.config),
+          bull: new Bull(Job.key, config),
           Job,
           name: Job.key,
           handle: Job.handle,
@@ -95,13 +100,13 @@ class Queue {
     }
   }
 
-  ui () {
+  ui (port = 9999) {
     BullBoard.setQueues(Object.values(this.queues).map(queue => queue.bull))
 
     const { UI } = BullBoard
 
-    const server = UI.listen(9999, () => {
-      this.Logger.info('bull board on http://localhost:9999')
+    const server = UI.listen(port, () => {
+      this.Logger.info(`bull board on http://localhost:${port}`)
     })
 
     const shutdown = () => {
@@ -161,6 +166,8 @@ class Queue {
 
     process.on('SIGTERM', shutdown)
     process.on('SIGINT', shutdown)
+
+    return this
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -394,10 +394,10 @@ braces@^3.0.1:
   dependencies:
     fill-range "^7.0.1"
 
-bull-board@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/bull-board/-/bull-board-0.5.0.tgz#54d1ac05b7d21e0023f82a8cd53f86f042232dc7"
-  integrity sha512-GePnFFGvQzidKj+tDtF2cfqoMuomnwysRxtgRc48nFuuRvQ562K4Pdlf89hZObnYqk1JWzjZslBzmI+KfnO+Gw==
+bull-board@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/bull-board/-/bull-board-0.6.0.tgz#eb2cdb06c3058a581c6047beb2bb7554362842b7"
+  integrity sha512-Rx4FoVo5PUC8kuXpsRY/ewj2q/uTk/TwaA2mrd6Ijh60NCGBRDcIJN+Hk/dZoHXJWDwJBrcTp3Q42cekxbyv7Q==
   dependencies:
     body-parser "^1.17.2"
     bull "3.11.0"


### PR DESCRIPTION
Now you don't need use `redis` configuration installed with the `@adonisjs/redis` provider.

Your configuration is passed in `config/bull.js` file:
```js
"use strict";

const Env = use("Env");

module.exports = {
  // redis connection
  connection: Env.get("BULL_CONNECTION", "bull"),
  bull: {
    redis: {
      host: "127.0.0.1",
      port: 6379,
      password: null,
      db: 0,
      keyPrefix: ""
    }
  },
  other: "redis://redis.example.com?password=correcthorsebatterystaple"
};
```

At the `Job` class you can also specify a different connection by the `connection` static get method.