### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ Create a file to initiate `Bull` at `preloads/bull.js`:
 ```js
 const Bull = use("Rocketseat/Bull");
 
-Bull.process()
-  // Optionally you can start BullBoard:
-  .ui(9999); // http://localhost:9999
+Bull.process();
+// Optionally you can start BullBoard:
+Bull.ui(9999); // http://localhost:9999
 // You don't need to specify the port, the default number is 9999
 ```
 


### PR DESCRIPTION
Current `preloads/bull.js` in the `README.md` doesn't seem to work. Works on my end when edited to:

```js
const Bull = use("Rocketseat/Bull");

Bull.process();
// Optionally you can start BullBoard:
Bull.ui(9999); // http://localhost:9999
// You don't need to specify the port, the default number is 9999
```

