### PR TITLE
chore: Create Issue and PR templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Learn how to add code owners here:
+# https://help.github.com/en/articles/about-code-owners
+
+*             @jpedroschmitz
+*.js          @HigoRibeiro

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,53 @@
+---
+name: Bug report
+about: Create a report to help us improve
+---
+
+<!-- Verify first that your issue is not already reported -->
+
+<!-- Please use this template while reporting a bug and provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner. Thanks! -->
+
+<!-- If possible complete *all* sections as described. Don't remove any section. -->
+
+**Description of bug**
+
+<!-- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+
+<!--
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+-->
+
+**Expected behavior**
+
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Exception or Error**
+
+<pre><code>
+<!-- If the issue is accompanied by an exception or an error, please share it below: -->
+<!-- ✍️-->
+</code></pre>
+
+**Screenshots**
+
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+**Environment:**
+
+<!--
+ Add information about your environment
+ - OS: [e.g. Ubuntu, Windows, macOS]
+ - Node [e.g 12.0.0]
+ - Adonis [e.g 4.1.0]
+ - Etc
+-->
+
+**Additional context**
+
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/documentation-report.md
+++ b/.github/ISSUE_TEMPLATE/documentation-report.md
@@ -1,0 +1,18 @@
+---
+name: Documentation report
+about: Use this template for documentation related issues
+---
+
+<!-- Verify first that your issue is not already reported -->
+
+<!-- Please only use this template for documentation related issues -->
+
+<!-- If possible complete *all* sections as described. Don't remove any section. -->
+
+**Description of issue**
+
+<!-- A clear description what needs changing, why should it be changed? How is it useful? -->
+
+**Usage example**
+
+<!-- Is there a usage example? -->

--- a/.github/ISSUE_TEMPLATE/enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-request.md
@@ -1,0 +1,26 @@
+---
+name: Enhancement request
+about: Suggest an idea for this project
+---
+
+<!-- Verify first that your issue is not already reported -->
+
+<!-- Please only use this template for submitting enhancement requests -->
+
+<!-- If possible complete *all* sections as described. Don't remove any section. -->
+
+**What would you like to be added**:
+
+<!-- A clear and concise description of what would you like to be added. -->
+
+**Why is this needed**:
+
+<!-- A clear and concise description of why is it needed. -->
+
+**Is your enhancement request related to a problem? Please describe.**
+
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+**Additional context**
+
+<!-- Add any other context or screenshots about the enhancement request here. -->

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,19 @@
+<!-- If this is your first time, please read our contribution guidelines: (https://github.com/Rocketseat/adonis-bull/blob/master/.github/CONTRIBUTING.md) -->
+
+<!-- Verify first that your pull request is not already proposed -->
+
+<!-- Refrain from using any language other than English -->
+
+<!-- Ensure you have added or ran the appropriate tests for your PR -->
+
+**Changes proposed**
+<!--- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
+
+<!--- Does this PR introduce a breaking change? -->
+
+<!--- What is the current behavior? (You can also link to an open issue here) -->
+
+<!--- What is the new behavior (if this is a feature change)?** -->
+
+**Additional context**
+<!-- Add any other context or screenshots about the feature request here. -->


### PR DESCRIPTION
In this PR the following updates were made:

- Include Issue templates for Bug requests, documentation reports, and enhancement requests;
- Include a PR template;
- Add [CODEOWNERS](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners).