### PR TITLE
fix: Use handle method by instance

### DIFF
--- a/src/BullManager.ts
+++ b/src/BullManager.ts
@@ -54,7 +54,6 @@ export class BullManager implements BullManagerContract {
         ...jobDefinition,
         instance: jobDefinition,
         listeners: jobListeners,
-        handle: jobDefinition.handle,
         boot: jobDefinition.boot,
       })
 
@@ -153,7 +152,7 @@ export class BullManager implements BullManagerContract {
 
       const processor: Processor = async (job) => {
         try {
-          return await jobDefinition.handle(job)
+          return await jobDefinition.instance.handle(job)
         } catch (error) {
           await this.handleException(error, job)
           return Promise.reject(error)


### PR DESCRIPTION
**Changes proposed**
This PR makes the processor use the manipulation method by the instance

**Additional context**
Currently we use the function extracted from the job class, this causes it to lose context and consequently does not see the other methods of the class.

Closes: #71 
This PR Resolves OSS-79