### PR TITLE
chore: Add UI custom host

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ const Bull = use('Rocketseat/Bull')
 
 Bull.process()
   // Optionally you can start BullBoard:
-  .ui(9999) // http://localhost:9999
-// You don't need to specify the port, the default number is 9999
+  .ui(9999, 'localhost') // http://localhost:9999
+// You don't need to specify either port or hostname, the default port number is 9999 and the default hostname is localhost
 ```
 
 Add .preLoad in server.js to initialize the bull preload

--- a/src/Queue.js
+++ b/src/Queue.js
@@ -100,15 +100,15 @@ class Queue {
     }
   }
 
-  ui(port = 9999) {
+  ui(port = 9999, hostname = 'localhost') {
     BullBoard.setQueues(
       Object.values(this.queues).map(
         (queue) => new BullBoard.BullAdapter(queue.bull)
       )
     )
 
-    const server = BullBoard.router.listen(port, () => {
-      this.Logger.info(`bull board on http://localhost:${port}`)
+    const server = BullBoard.router.listen(port, hostname, () => {
+      this.Logger.info(`bull board on http://${hostname}:${port}`)
     })
 
     const shutdown = () => {


### PR DESCRIPTION
**Changes proposed**
This PR adds a hostname to ui function and change readme

**Additional context**
I was trying to use bullBoard inside a docker container, but to do it I needed to bind the hostname `localhost` to `0.0.0.0`.

