### PR TITLE
chore: Add removeRepeatable and getRepeatableJobs methods

### DIFF
--- a/src/Queue.js
+++ b/src/Queue.js
@@ -75,6 +75,19 @@ class Queue {
     return job
   }
 
+  removeRepeatable(name, repeat) {
+    const queue = this.get(name)
+
+    return queue.bull.removeRepeatable('__default__', repeat)
+  }
+
+  getRepeatableJobs(name) {
+    const queue = this.get(name)
+    const jobs = queue.bull.getRepeatableJobs()
+
+    return jobs
+  }
+
   schedule(name, data, date, options) {
     let delay
 


### PR DESCRIPTION
**Changes proposed**
This PR adds the possibility to interact with some methods of [repeatable](https://github.com/OptimalBits/bull/blob/46fcba14bc01885c1ca518b3399ec474bb88b71d/lib/repeatable.js) jobs.